### PR TITLE
add IgnoredRequestHeaders option to config

### DIFF
--- a/src/Giraffe.SerilogExtensions/RequestLogEnricher.fs
+++ b/src/Giraffe.SerilogExtensions/RequestLogEnricher.fs
@@ -97,6 +97,7 @@ type RequestLogEnricher(context: HttpContext, config: SerilogConfig, requestId: 
                 ]
 
                 headerValues
+                |> List.filter (fun (key,_) -> not (List.exists ((=) key) config.IgnoredRequestHeaders))
                 |> Map.ofList
                 |> Enrichers.eventProperty "RequestHeaders"
                 |> logEvent.AddOrUpdateProperty

--- a/src/Giraffe.SerilogExtensions/SerilogConfig.fs
+++ b/src/Giraffe.SerilogExtensions/SerilogConfig.fs
@@ -2,6 +2,8 @@ namespace Giraffe.SerilogExtensions
 
 open Giraffe
 open Microsoft.AspNetCore.Http
+open Microsoft.Net.Http.Headers
+
 type FieldChoser<'t> = Choser of string list
 
 type RequestLogData = RequestLogData
@@ -11,6 +13,7 @@ type ResponseLogData = ResponseLogData
 type SerilogConfig = 
     { IgnoredRequestFields : FieldChoser<RequestLogData>
       IgnoredResponseFields : FieldChoser<ResponseLogData>
+      IgnoredRequestHeaders: string list
       RequestMessageTemplate : string
       ResponseMessageTemplate : string
       ErrorMessageTemplate : string
@@ -20,6 +23,7 @@ type SerilogConfig =
     static member defaults = 
         { IgnoredRequestFields = Choser [ ] 
           IgnoredResponseFields = Choser [ ]
+          IgnoredRequestHeaders = [ HeaderNames.Authorization; HeaderNames.Cookie ]
           RequestMessageTemplate = "{Method} Request at {Path}"
           ResponseMessageTemplate = "{Method} Response (StatusCode {StatusCode}) at {Path} took {Duration} ms"
           ErrorMessageTemplate = "Error at {Path} took {Duration} ms"


### PR DESCRIPTION
## Proposed Changes

This change introduces the `IgnoredRequestHeaders` to `SerilogConfig`. This allows users to define which headers the log should omit.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [X] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Related to #11 