### PR TITLE
Update LicenseUrl

### DIFF
--- a/src/Giraffe.SerilogExtensions/Giraffe.SerilogExtensions.fsproj
+++ b/src/Giraffe.SerilogExtensions/Giraffe.SerilogExtensions.fsproj
@@ -10,7 +10,7 @@
     <!-- summary is not migrated from project.json, but you can use the <Description> property for that if needed. -->
     <PackageTags>f#, fsharp, serilog, giraffe, logging, tracing</PackageTags>
     <PackageProjectUrl>https://github.com/zaid-ajaj/Giraffe.SerilogExtensions</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/zaid-ajaj/Giraffe.SerilogExtensions/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseUrl>https://github.com/zaid-ajaj/Giraffe.SerilogExtensions/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <Version>2.2.0</Version>


### PR DESCRIPTION
In order to properly show the license in nuget, the licenseUrl needs to point to a valid URL

Ref: https://www.nuget.org/packages/Giraffe.SerilogExtensions